### PR TITLE
fix: adapt Decksmith to consume structured backend AI response

### DIFF
--- a/src/Components/Decksmith/DeckPanel.tsx
+++ b/src/Components/Decksmith/DeckPanel.tsx
@@ -1,4 +1,3 @@
-// src/Components/Decksmith/DeckPanel.tsx
 import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
@@ -32,7 +31,7 @@ const DeckPanel = ({ deck }: Props) => {
     try {
       await postDeckList({
         commander: deck.commander,
-        cards: deck.cards,
+        cards: deck.cards.map(c => ({ id: c._id, quantity: c.quantity })),
         name: `${deck.commander} deck`,
         format: 'Commander',
       });
@@ -48,14 +47,24 @@ const DeckPanel = ({ deck }: Props) => {
   return (
     <Panel>
       <Header>
+        {deck.commanderImageUri && (
+          <CommanderImage src={deck.commanderImageUri} alt={deck.commander} />
+        )}
         <DeckTitle>{deck.commander}</DeckTitle>
         <Meta>Commander · {deck.cards.length + 1} cards</Meta>
       </Header>
 
       <CardList>
-        <CardRow><strong>{deck.commander}</strong> — Commander</CardRow>
-        {deck.cards.map((name, i) => (
-          <CardRow key={`${name}-${i}`}>{name}</CardRow>
+        <SectionLabel>Commander</SectionLabel>
+        <CardRow>
+          <CardName>{deck.commander}</CardName>
+        </CardRow>
+        <SectionLabel>Deck ({deck.cards.length})</SectionLabel>
+        {deck.cards.map((card, i) => (
+          <CardRow key={`${card._id}-${i}`}>
+            <CardName>{card.quantity > 1 ? `${card.quantity}x ` : ''}{card.name}</CardName>
+            {card.role && <CardRole>{card.role}</CardRole>}
+          </CardRow>
         ))}
       </CardList>
 
@@ -89,6 +98,13 @@ const Header = styled.div`
   flex-shrink: 0;
 `;
 
+const CommanderImage = styled.img`
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+  display: block;
+`;
+
 const DeckTitle = styled.h3`
   margin: 0 0 0.25rem;
   font-size: 1rem;
@@ -111,11 +127,36 @@ const CardList = styled.div`
   gap: 0.1rem;
 `;
 
+const SectionLabel = styled.div`
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #9ca3af;
+  letter-spacing: 0.05em;
+  margin: 0.5rem 0 0.25rem;
+`;
+
 const CardRow = styled.div`
-  font-size: 0.82rem;
-  color: #374151;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
   padding: 0.2rem 0;
   border-bottom: 1px solid #f9fafb;
+`;
+
+const CardName = styled.span`
+  font-size: 0.82rem;
+  color: #374151;
+  flex: 1;
+`;
+
+const CardRole = styled.span`
+  font-size: 0.7rem;
+  color: #6b7280;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+  flex-shrink: 0;
 `;
 
 const Footer = styled.div`

--- a/src/Components/Navbar.tsx
+++ b/src/Components/Navbar.tsx
@@ -63,9 +63,12 @@ export default Navbar;
 
 const NavigationContainer = styled.div`
   position: fixed;
-  top: 0px;
+  top: 0;
   width: 100%;
-  margin: 2% 0;
+  z-index: 100;
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.75rem 0;
 `;
 
 const LinkItem = styled(Link)`

--- a/src/pages/Decksmith.tsx
+++ b/src/pages/Decksmith.tsx
@@ -1,9 +1,7 @@
-// src/pages/Decksmith.tsx
 import { useState } from 'react';
 import styled from 'styled-components';
 import { Message, ParsedDeck } from '../types/chat';
 import { buildPromptFromMessages } from '../utils/chatPrompt';
-import { parseDeckFromAIText } from '../utils/parseDeckFromAIText';
 import { fetchMTGIdea } from '../services/aiService';
 import MessageList from '../Components/Chat/MessageList';
 import ChatInput from '../Components/Chat/ChatInput';
@@ -22,16 +20,17 @@ const Decksmith = () => {
 
     try {
       const prompt = buildPromptFromMessages(nextMessages);
-      const aiText = await fetchMTGIdea(prompt);
-      const deck = parseDeckFromAIText(aiText);
+      const deck = await fetchMTGIdea(prompt);
 
       const aiMsg: Message = {
         role: 'assistant',
-        content: deck ? aiText : 'No deck found — try rephrasing your request.',
+        content: deck.strategy
+          ? `Here's your **${deck.commander}** deck!\n\n${deck.strategy}`
+          : `Here's your **${deck.commander}** deck!`,
         timestamp: Date.now(),
       };
       setMessages(prev => [...prev, aiMsg]);
-      if (deck) setCurrentDeck(deck);
+      setCurrentDeck(deck);
     } catch {
       const errorMsg: Message = {
         role: 'assistant',
@@ -60,9 +59,13 @@ const Decksmith = () => {
 export default Decksmith;
 
 const Layout = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
-  width: 100%;
-  height: 100%;
+  padding-top: 72px;
   overflow: hidden;
   background: #f9fafb;
 `;
@@ -73,6 +76,8 @@ const ChatColumn = styled.div`
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
+  background: #f9fafb;
+  border-right: 1px solid #e5e7eb;
 `;
 
 const DeckColumn = styled.div`

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,14 +1,25 @@
 import axios from "axios";
 import API_ENDPOINT from "../Constants/api";
+import { ParsedDeck } from "../types/chat";
 
-export const fetchMTGIdea = async (prompt: string): Promise<string> => {
+export const fetchMTGIdea = async (prompt: string): Promise<ParsedDeck> => {
   try {
     const response = await axios.post(
-      API_ENDPOINT.AI_DEEPSEEK_BASE,
-      { prompt },
+      API_ENDPOINT.AI_GENERATE,
+      { prompt, format: 'Commander' },
       { withCredentials: true }
     );
-    return response.data.result;
+    const data = response.data;
+    if (!data.commander || !Array.isArray(data.cards)) {
+      throw new Error('Unexpected response shape');
+    }
+    return {
+      generationId: data.generation_id ?? '',
+      commander: data.commander.name,
+      commanderImageUri: data.commander.image_uris?.normal ?? data.commander.image_uris?.small ?? '',
+      cards: data.cards,
+      strategy: data.strategy ?? '',
+    };
   } catch (error) {
     console.error("AI service error:", error);
     throw new Error("Failed to fetch AI response");

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -4,8 +4,18 @@ export interface Message {
   timestamp: number;
 }
 
+export interface CardEntry {
+  _id: string;
+  name: string;
+  quantity: number;
+  role: string;
+  image_uris: Record<string, string>;
+}
+
 export interface ParsedDeck {
+  generationId: string;
   commander: string;
-  cards: string[];   // the 99 non-commander cards
-  rawText: string;   // original AI response, kept for debugging
+  commanderImageUri: string;
+  cards: CardEntry[];
+  strategy: string;
 }


### PR DESCRIPTION
Backend returns rich JSON (commander object, cards with image_uris/role) instead of plain text. Updated ParsedDeck type, aiService, Decksmith page, and DeckPanel to use structured data directly — removing the text-parsing approach. DeckPanel now shows the commander card image and card roles.